### PR TITLE
Turn off warnings for using head or tail, or remove their use.

### DIFF
--- a/bench/Problems/P61Bench.hs
+++ b/bench/Problems/P61Bench.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2021 Yoo Chung
 License: GPL-3.0-or-later

--- a/ninetynine.cabal
+++ b/ninetynine.cabal
@@ -21,7 +21,7 @@ homepage:       https://ninetynine.haskell.chungyc.org/
 bug-reports:    https://github.com/chungyc/ninetynine/issues
 author:         Yoo Chung
 maintainer:     dev@chungyc.org
-copyright:      Copyright (C) 2023 Yoo Chung
+copyright:      Copyright (C) 2024 Yoo Chung
 license:        GPL-3.0-or-later
 license-file:   LICENSE
 build-type:     Simple

--- a/src/Problems/Graphs.hs
+++ b/src/Problems/Graphs.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Supporting definitions for graph problems
 Copyright: Copyright (C) 2023 Yoo Chung

--- a/src/Problems/P50.hs
+++ b/src/Problems/P50.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Huffman codes
 Copyright: Copyright (C) 2021 Yoo Chung

--- a/src/Problems/P91.hs
+++ b/src/Problems/P91.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Knight's tour
 Copyright: Copyright (C) 2023 Yoo Chung

--- a/src/Problems/P98.hs
+++ b/src/Problems/P98.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Nonograms
 Copyright: Copyright (C) 2021 Yoo Chung

--- a/src/Problems/P99.hs
+++ b/src/Problems/P99.hs
@@ -12,6 +12,7 @@ import           Problems.Crosswords
 import qualified Solutions.P99       as Solution
 
 -- $setup
+-- >>> :set -Wno-x-partial -Wno-unrecognised-warning-flags
 -- >>> import Data.Maybe (fromJust)
 -- >>> import Problems.Crosswords
 

--- a/src/Solutions/P10.hs
+++ b/src/Solutions/P10.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Run-length encoding of a list
 Copyright: Copyright (C) 2021 Yoo Chung

--- a/src/Solutions/P11.hs
+++ b/src/Solutions/P11.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Modified run-length encoding
 Copyright: Copyright (C) 2021 Yoo Chung

--- a/src/Solutions/P36.hs
+++ b/src/Solutions/P36.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: List of prime factors and their multiplicities
 Copyright: Copyright (C) 2021 Yoo Chung

--- a/src/Solutions/P44.hs
+++ b/src/Solutions/P44.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Gaussian primes
 Copyright: Copyright (C) 2022 Yoo Chung

--- a/src/Solutions/P50.hs
+++ b/src/Solutions/P50.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Huffman codes
 Copyright: Copyright (C) 2021 Yoo Chung

--- a/src/Solutions/P79.hs
+++ b/src/Solutions/P79.hs
@@ -8,7 +8,7 @@ Some solutions to "Problems.P79" of Ninety-Nine Haskell "Problems".
 -}
 module Solutions.P79 (calculatePostfix) where
 
-import           Control.Monad (guard, mzero)
+import           Control.Monad (mzero)
 import           Control.Monad.Identity
 import           Control.Monad.State
 import           Control.Monad.Trans.Maybe
@@ -70,6 +70,8 @@ push x = modify (x:)
 pop :: Calculation Integer
 pop = do
   xs <- get
-  guard $ not $ null xs
-  put $ tail xs
-  return $ head xs
+  case xs of
+    [] -> mzero
+    (x:xs') -> do
+      put xs'
+      return x

--- a/src/Solutions/P82.hs
+++ b/src/Solutions/P82.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Cycles with a given vertex
 Copyright: Copyright (C) 2021 Yoo Chung

--- a/src/Solutions/P84.hs
+++ b/src/Solutions/P84.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Construct minimum spanning tree
 Copyright: Copyright (C) 2021 Yoo Chung

--- a/src/Solutions/P85.hs
+++ b/src/Solutions/P85.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Graph isomorphism
 Copyright: Copyright (C) 2023 Yoo Chung

--- a/src/Solutions/P91.hs
+++ b/src/Solutions/P91.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Knight's tour
 Copyright: Copyright (C) 2023 Yoo Chung

--- a/src/Solutions/P92.hs
+++ b/src/Solutions/P92.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
 
 {- |
 Description: Graceful tree labeling

--- a/src/Solutions/P97.hs
+++ b/src/Solutions/P97.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Sudoku
 Copyright: Copyright (C) 2023 Yoo Chung

--- a/src/Solutions/P98.hs
+++ b/src/Solutions/P98.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {- |
 Description: Nonograms
 Copyright: Copyright (C) 2023 Yoo Chung

--- a/src/Solutions/P99.hs
+++ b/src/Solutions/P99.hs
@@ -153,7 +153,9 @@ findSites g orient = concatMap (evalState find . initial) $ zip [0..] g
                                          , fssChars = []
                                          , fssLocs = []
                                          }
-    step = modify $ \st -> st { fssSpots = tail $ fssSpots st
+    step = modify $ \st -> st { fssSpots = case fssSpots st of
+                                  [] -> error "no more spots"
+                                  (_:xs) -> xs
                               , fssPos = 1 + fssPos st
                               }
 
@@ -289,7 +291,10 @@ guess' :: RandomGen g => Partial -> State g (Maybe Partial)
 guess' p = do
   tiebreakers <- do gen <- state split
                     return (randoms gen :: [Int])
-  let siteIndex = snd $ head $ sortOn count $ zip tiebreakers $ Map.keys $ candidates p
+  let sitePicks = sortOn count $ zip tiebreakers $ Map.keys $ candidates p
+  let siteIndex = snd $ case sitePicks of
+        (x:_) -> x
+        [] -> error "no more sites"
   wordList <- state $ randomPermute $ candidates p ! siteIndex
   state $ tryGuesses p siteIndex wordList
   where

--- a/test/Problems/P08Spec.hs
+++ b/test/Problems/P08Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P09Spec.hs
+++ b/test/Problems/P09Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P10Spec.hs
+++ b/test/Problems/P10Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P11Spec.hs
+++ b/test/Problems/P11Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P19Spec.hs
+++ b/test/Problems/P19Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P23Spec.hs
+++ b/test/Problems/P23Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P24Spec.hs
+++ b/test/Problems/P24Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P25Spec.hs
+++ b/test/Problems/P25Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P38Spec.hs
+++ b/test/Problems/P38Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P81Spec.hs
+++ b/test/Problems/P81Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P82Spec.hs
+++ b/test/Problems/P82Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P87Spec.hs
+++ b/test/Problems/P87Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P88Spec.hs
+++ b/test/Problems/P88Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P91Spec.hs
+++ b/test/Problems/P91Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P97Spec.hs
+++ b/test/Problems/P97Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P98Spec.hs
+++ b/test/Problems/P98Spec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-unrecognised-warning-flags #-}
+
 {-|
 Copyright: Copyright (C) 2023 Yoo Chung
 License: GPL-3.0-or-later

--- a/test/Problems/P99Spec.hs
+++ b/test/Problems/P99Spec.hs
@@ -135,7 +135,8 @@ addToSolution g (w,x,y,False)
 -- I.e., we don't like sites that we didn't add ourselves.
 -- Reject grids which have 2x2 blank areas.
 isValid :: [[Maybe Char]] -> Bool
-isValid g = all isValidRows $ zip g $ tail g
+isValid [] = False
+isValid g@(_:gs) = all isValidRows $ zip g gs
   where isValidRows ([], []) = True
         isValidRows (Just _ : Just _ : _,
                      Just _ : Just _ : _) = False


### PR DESCRIPTION
Allows building with GHC 9.8.2.